### PR TITLE
FS-898 - Add env variables to yaml to override locust configs for fund store

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
     with:
       app_name: ${{ github.event.repository.name }}
       api: true
-      spawn-rate: 3
+      spawn-rate: 4
     secrets:
       CF_API: ${{secrets.CF_API}}
       CF_ORG: ${{secrets.CF_ORG}}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test_and_deploy:
-    uses: communitiesuk/funding-design-service-workflows/.github/workflows/deploy.yml@performance_testing
+    uses: communitiesuk/funding-design-service-workflows/.github/workflows/deploy.yml@performance_testing_fixes
     with:
       app_name: ${{ github.event.repository.name }}
       api: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
     with:
       app_name: ${{ github.event.repository.name }}
       api: true
-      users: 2
+      spawn-rate: 3
     secrets:
       CF_API: ${{secrets.CF_API}}
       CF_ORG: ${{secrets.CF_ORG}}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,10 +8,11 @@ on:
 
 jobs:
   test_and_deploy:
-    uses: communitiesuk/funding-design-service-workflows/.github/workflows/deploy.yml@main
+    uses: communitiesuk/funding-design-service-workflows/.github/workflows/deploy.yml@performance_testing
     with:
       app_name: ${{ github.event.repository.name }}
       api: true
+      users: 10
     secrets:
       CF_API: ${{secrets.CF_API}}
       CF_ORG: ${{secrets.CF_ORG}}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,11 +8,13 @@ on:
 
 jobs:
   test_and_deploy:
-    uses: communitiesuk/funding-design-service-workflows/.github/workflows/deploy.yml@performance_testing_fixes
+    uses: communitiesuk/funding-design-service-workflows/.github/workflows/deploy.yml@main
     with:
       app_name: ${{ github.event.repository.name }}
       api: true
-      spawn-rate: 4
+      users: 2
+      spawn-rate: 2
+      run-time: 11s
     secrets:
       CF_API: ${{secrets.CF_API}}
       CF_ORG: ${{secrets.CF_ORG}}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
     with:
       app_name: ${{ github.event.repository.name }}
       api: true
-      users: 10
+      include: ${{ env.users = 1 }}
     secrets:
       CF_API: ${{secrets.CF_API}}
       CF_ORG: ${{secrets.CF_ORG}}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
     with:
       app_name: ${{ github.event.repository.name }}
       api: true
-      include: ${{ env.users = 1 }}
+      users: 2
     secrets:
       CF_API: ${{secrets.CF_API}}
       CF_ORG: ${{secrets.CF_ORG}}

--- a/README.md
+++ b/README.md
@@ -65,3 +65,6 @@ the following while in your virtual enviroment:
 
 Once the above is done you will have autoformatting and pep8 compliance built
 into your workflow. You will be notified of any pep8 errors during commits.
+
+In deploy.yml, there are three environment variables called users, spawn-rate and run-time. These are used 
+to override the locust config if the performance tests need to run with different configs for fund store. 


### PR DESCRIPTION
Jira Ticket:
https://digital.dclg.gov.uk/jira/browse/FS-898

I have added three environment variables called users, spawn-rate and run-time which can be used to override the locust config if they need to be set differently for fund store rather than use the default values set in deploy.yml in the workflows repo:

https://github.com/communitiesuk/funding-design-service-workflows/blob/main/.github/workflows/deploy.yml

I have also updated the README. 


NOTE: That following the recent changes done here:
https://github.com/communitiesuk/funding-design-service-workflows/pull/6

The performance tests will only run on the main branch. 