### PR TITLE
FS-657: fix dockerfile

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim-bullseye
+FROM python:3.10-bullseye
 
 WORKDIR /app
 COPY requirements.txt requirements.txt


### PR DESCRIPTION
Previously build was failing with `Exception: command 'gcc' failed: No such file or directory` due to a nested dependency. Switch to non-slim image which includes `gcc`.
