### PR TITLE
FS-885 and FS-886 Configuring COF fund and round and some data model changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Built with Flask.
 
 ## Installation
 
-Clone the repository
+Clone the repository.
 
 ### Create a Virtual environment
 

--- a/core/data_operations/fund_data.py
+++ b/core/data_operations/fund_data.py
@@ -11,7 +11,7 @@ FUND_DATA = [
         "description": (
             "The Community Ownership Fund is a £150 million fund over 4 years to support community groups across "
             "England, Wales, Scotland and Northern Ireland to take ownership of assets which are at risk of being "
-            "lost to the community. "
+            "lost to the community."
         ),
     },
 ]

--- a/core/data_operations/fund_data.py
+++ b/core/data_operations/fund_data.py
@@ -6,9 +6,12 @@ from core.dummy_dao import FundDAO
 
 FUND_DATA = [
     {
-        "fund_name": "Funding service design",
-        "fund_description": (
-            "A fund designed to test the funding service design dev team."
+        "id": "47aef2f5-3fcb-4d45-acb5-f0152b5f03c4",
+        "name": "Community Ownership Fund",
+        "description": (
+            "The Community Ownership Fund is a £150 million fund over 4 years to support community groups across "
+            "England, Wales, Scotland and Northern Ireland to take ownership of assets which are at risk of being "
+            "lost to the community. "
         ),
     },
 ]

--- a/core/data_operations/round_data.py
+++ b/core/data_operations/round_data.py
@@ -9,11 +9,28 @@ ROUND_DATA = [
         "id": "c603d114-5364-4474-a0c4-c41cbf4d3bbd",
         "title": "Round 2 Window 2",
         "fund_id": "47aef2f5-3fcb-4d45-acb5-f0152b5f03c4",
-        "assessment_criteria_weighting": {
-            "strategy": 0.35,
-            "deliverability": 0.35,
-            "value_for_money": 0.3,
-        },
+        "assessment_criteria_weighting": [
+            {
+                "id": "e2fd30d2-9207-421c-b8b3-c961bcee138b",
+                "name": "Strategic case",
+                "value": 0.30
+            },
+            {
+                "id": "e557773a-74c9-43ee-a52c-88ccae279d08",
+                "name": "Management case",
+                "value": 0.30
+            },
+            {
+                "id": "9e282cdb-6c42-4430-9563-dc4995b59bdd",
+                "name": "Potential to delivery community benefits",
+                "value": 0.30
+            },
+            {
+                "id": "6020db6c-df67-4932-a2f3-2e9dd1934164",
+                "name": "Added value to the community",
+                "value": 0.10
+            }
+        ],
         "opens": "2022-09-01 00:00:01",
         "deadline": "2023-01-30 00:00:01",
         "assessment_deadline": "2023-03-20 00:00:01",

--- a/core/data_operations/round_data.py
+++ b/core/data_operations/round_data.py
@@ -6,72 +6,17 @@ from core.dummy_dao import RoundDAO
 
 ROUND_DATA = [
     {
-        "round_id": "spring",
-        "round_title": "Spring",
-        "fund_id": "funding-service-design",
-        "eligibility_criteria": {"max_project_cost": 1200000},
+        "id": "c603d114-5364-4474-a0c4-c41cbf4d3bbd",
+        "title": "Round 2 Window 2",
+        "fund_id": "47aef2f5-3fcb-4d45-acb5-f0152b5f03c4",
         "assessment_criteria_weighting": {
             "strategy": 0.35,
             "deliverability": 0.35,
             "value_for_money": 0.3,
         },
-        "opens": "2025-12-28 00:00:01",
-        "deadline": "2025-12-28 00:00:00",
-        "assessment_deadline": "2026-1-28 00:00:00",
-        "application_url": "https://funding-service-design-"
-        + "form-runner.london.cloudapps.digital/baseline-"
-        + "application-questions",
-    },
-    {
-        "round_id": "summer",
-        "round_title": "Summer",
-        "fund_id": "funding-service-design",
-        "eligibility_criteria": {"max_project_cost": 1500000},
-        "assessment_criteria_weighting": {
-            "strategy": 0.25,
-            "deliverability": 0.45,
-            "value_for_money": 0.3,
-        },
-        "opens": "2026-3-28 00:00:01",
-        "deadline": "2026-4-28 00:00:00",
-        "assessment_deadline": "2026-5-28 00:00:00",
-        "application_url": "https://funding-service-design-"
-        + "form-runner.london.cloudapps.digital/baseline-"
-        + "application-questions",
-    },
-    {
-        "round_id": "autumn",
-        "round_title": "Autumn",
-        "fund_id": "funding-service-design",
-        "eligibility_criteria": {"max_project_cost": 10400000},
-        "assessment_criteria_weighting": {
-            "strategy": 0.2,
-            "deliverability": 0.6,
-            "value_for_money": 0.2,
-        },
-        "opens": "2026-6-28 00:00:01",
-        "deadline": "2026-7-28 00:00:00",
-        "assessment_deadline": "2026-8-28 00:00:00",
-        "application_url": "https://funding-service-design-"
-        + "form-runner.london.cloudapps.digital/funding-application",
-    },
-    {
-        "round_id": "winter",
-        "round_title": "Winter",
-        "fund_id": "funding-service-design",
-        "eligibility_criteria": {"max_project_cost": 10400000},
-        "assessment_criteria_weighting": {
-            "strategy": 0.3,
-            "deliverability": 0.4,
-            "value_for_money": 0.3,
-        },
-        "opens": "2026-9-28 00:00:01",
-        "deadline": "2026-10-28 00:00:00",
-        "assessment_deadline": "2026-11-28 00:00:00",
-        "application_url": (
-            "https://funding-service-design-"
-            "form-runner.london.cloudapps.digital/funding-application"
-        ),
+        "opens": "2022-09-01 00:00:01",
+        "deadline": "2023-01-30 00:00:01",
+        "assessment_deadline": "2023-03-20 00:00:01",
     },
 ]
 

--- a/core/dummy_dao.py
+++ b/core/dummy_dao.py
@@ -17,9 +17,7 @@ class FundDAO:
         return list(self.funds.values())
 
     def create(self, data):
-        key = slugify(data["fund_name"])
-        data["fund_id"] = key
-        self.funds[key] = data
+        self.funds[data["id"]] = data
 
     def load_dummy(self, fund_data):
         for fund in fund_data:
@@ -41,7 +39,7 @@ class RoundDAO:
             (
                 round
                 for round in fund_round_list
-                if round["round_id"] == round_id
+                if round["id"] == round_id
             ),
             None,
         )
@@ -55,9 +53,7 @@ class RoundDAO:
         return fund_round_list
 
     def create(self, data):
-        key = slugify(data["round_title"])
-        data["round_id"] = key
-        self.rounds[key] = data
+        self.rounds[data["id"]] = data
 
     def load_dummy(self, round_data):
         for round in round_data:

--- a/manifest.yml
+++ b/manifest.yml
@@ -6,9 +6,13 @@ applications:
   buildpacks:
   - https://github.com/cloudfoundry/python-buildpack.git
   command: gunicorn wsgi:app -c run/gunicorn/devtest.py
+  env:
+    FLASK_ENV: dev
 
 - name: funding-service-design-fund-store-test
   memory: 64M
   buildpacks:
   - https://github.com/cloudfoundry/python-buildpack.git
   command: gunicorn wsgi:app -c run/gunicorn/devtest.py
+  env:
+    FLASK_ENV: test

--- a/openapi/components.yml
+++ b/openapi/components.yml
@@ -20,7 +20,7 @@ components:
           - name
           - description
     AssessmentCriteriaWeighting:
-        type: object
+        type: array
         properties:
           strategy:
             type: number

--- a/openapi/components.yml
+++ b/openapi/components.yml
@@ -3,31 +3,22 @@ components:
     Fund:
         type: object
         properties:
-          fund_name:
+          name:
             type: string
             description: The name of the fund.
             example: "J's Sensible T-Shirt Fund"
-          fund_description:
+          description:
             type: string
             description: The description of the fund.
             example: "Help J buy more t-shirt."
-          fund_id:
+          id:
             type: string
             description: The fund ID, uniquely identifies the fund.
             example: "sdknbfs98yf48sfd"
         required:
-          - fund_name
-          - fund_description
-          - fund_id
-    EligibilityCriteria:
-        type: object
-        properties:
-          max_project_cost:
-            type: integer
-            description: Maximum project cost
-            example: 1000000
-        required:
-          - max_project_cost
+          - id
+          - name
+          - description
     AssessmentCriteriaWeighting:
         type: object
         properties:
@@ -59,11 +50,11 @@ components:
     Round:
         type: object
         properties:
-          round_id:
+          id:
             type: string
             description: id of rounds.
             example: "12345-qwert-....."
-          round_title:
+          title:
             type: string
             description: title or name of the round.
             example: "Spring"
@@ -71,13 +62,9 @@ components:
             type: string
             description: The fund ID, uniquely identifies the fund.
             example: "funding-service-design"
-          eligibility_criteria:
-            $ref: '#/components/schemas/EligibilityCriteria'
-            description: outlines the eligibility criteria for applicants
-            example:
           assessment_criteria_weighting:
             $ref: '#/components/schemas/AssessmentCriteriaWeighting'
-            description: outlines the eligibility criteria for applicants
+            description: assessment criteria weightings for application criteria.
             example:
           opens:
             type: string
@@ -91,20 +78,14 @@ components:
             type: string
             description: The date when the assessments will be completed
             example: "2022-12-25 00:00:00"
-          application_url:
-            type: string
-            description: The url for the online application form
-            example: "https://application-form-service/fund-id-round-id"
         required:
-          - round_id
-          - round_title
+          - id
           - fund_id
-          - eligibility_criteria
+          - title
           - assessment_criteria_weighting
           - opens
           - deadline
           - assessment_deadline
-          - application_url
     Error:
       type: object
       properties:

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,7 +1,5 @@
 import sys
 
-from slugify import slugify
-
 TEST_FUND_DATA = [
     {
         "id": "fb986cdc-8e02-477a-a7e0-41cf19dd7675",
@@ -20,11 +18,28 @@ TEST_ROUND_DATA = [
         "id": "3b1ae9e8-eda4-4910-a5dd-fc144f9a8ba1",
         "title": "Test Round 1",
         "fund_id": "fb986cdc-8e02-477a-a7e0-41cf19dd7675",
-        "assessment_criteria_weighting": {
-            "strategy": 0.3,
-            "deliverability": 0.4,
-            "value_for_money": 0.3,
-        },
+        "assessment_criteria_weighting": [
+            {
+                "id": "e2fd30d2-9207-421c-b8b3-c961bcee138b",
+                "name": "Strategic case",
+                "value": 0.30,
+            },
+            {
+                "id": "e557773a-74c9-43ee-a52c-88ccae279d08",
+                "name": "Management case",
+                "value": 0.30,
+            },
+            {
+                "id": "9e282cdb-6c42-4430-9563-dc4995b59bdd",
+                "name": "Potential to delivery community benefits",
+                "value": 0.30,
+            },
+            {
+                "id": "6020db6c-df67-4932-a2f3-2e9dd1934164",
+                "name": "Added value to the community",
+                "value": 0.10,
+            },
+        ],
         "opens": "2099-12-25 00:00:01",
         "deadline": "2099-12-26 00:00:00",
         "assessment_deadline": "2099-12-27 00:00:00",

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -4,27 +4,22 @@ from slugify import slugify
 
 TEST_FUND_DATA = [
     {
-        "fund_name": "Harry's breakfast fund",
-        "fund_description": (
-            "A fund designed to supply Harry's endless supply of muesli."
-        ),
+        "id": "fb986cdc-8e02-477a-a7e0-41cf19dd7675",
+        "name": "Test fund 1",
+        "description": "Test fund description 1",
     },
     {
-        "fund_name": "Ram's Get Fit Feb fund",
-        "fund_description": (
-            "A fund designed to supply gym memberships to home workers during"
-            " Feb."
-        ),
+        "id": "e356c266-68a8-4000-ad95-6e4d961f65b4",
+        "name": "Test fund 2",
+        "description": "Test fund description 2",
     },
 ]
 
-
 TEST_ROUND_DATA = [
     {
-        "round_id": "brekky",
-        "round_title": "Brekky",
-        "fund_id": "harry-s-breakfast-fund",
-        "eligibility_criteria": {"max_project_cost": 1},
+        "id": "3b1ae9e8-eda4-4910-a5dd-fc144f9a8ba1",
+        "title": "Test Round 1",
+        "fund_id": "fb986cdc-8e02-477a-a7e0-41cf19dd7675",
         "assessment_criteria_weighting": {
             "strategy": 0.3,
             "deliverability": 0.4,
@@ -33,41 +28,34 @@ TEST_ROUND_DATA = [
         "opens": "2099-12-25 00:00:01",
         "deadline": "2099-12-26 00:00:00",
         "assessment_deadline": "2099-12-27 00:00:00",
-        "application_url": (
-            "https://funding-service-design-"
-            "form-runner.london.cloudapps.digital/funding-application"
-        ),
     }
 ]
 
 # When processed by the api, a slugied fund-id is added to the fund
 # dictionary. We simulate this step here
-TEST_RESPONSE_FUND_DATA = [
-    {"fund_id": slugify(i["fund_name"]), **i} for i in TEST_FUND_DATA
-]
+TEST_RESPONSE_FUND_DATA = TEST_FUND_DATA
+
 # setting parent path to get default fund data
 sys.path.append("../core")
 from core.data_operations.fund_data import (  # noqa
     FUND_DATA as DEFAULT_FUND_DATA,
 )
 
-DEFAULT_RESPONSE_FUND_DATA = [
-    {"fund_id": slugify(i["fund_name"]), **i} for i in DEFAULT_FUND_DATA
-]
+DEFAULT_RESPONSE_FUND_DATA = DEFAULT_FUND_DATA
 
 
-HARRY_S_BREAKFAST_FUND = TEST_RESPONSE_FUND_DATA[0]
+TEST_FUND_ONE = TEST_RESPONSE_FUND_DATA[0]
 
 
-ROUNDS_IN_HARRY_S_BREAKFAST_FUND = [
+TEST_ROUNDS_IN_FUND_ONE = [
     dict
     for dict in TEST_ROUND_DATA
-    if dict["fund_id"] == "harry-s-breakfast-fund"
+    if dict["fund_id"] == "fb986cdc-8e02-477a-a7e0-41cf19dd7675"
 ]
 
 
-BREKKY_ROUND = [
+TEST_ROUND_ONE = [
     dict
-    for dict in ROUNDS_IN_HARRY_S_BREAKFAST_FUND
-    if dict["round_id"] == "brekky"
+    for dict in TEST_ROUNDS_IN_FUND_ONE
+    if dict["id"] == "3b1ae9e8-eda4-4910-a5dd-fc144f9a8ba1"
 ][0]

--- a/tests/test_funds.py
+++ b/tests/test_funds.py
@@ -4,10 +4,10 @@ A file containing all tests related to the fund endpoint.
 import asserts
 from flask import Flask
 from flask import request
-from tests.test_data import BREKKY_ROUND
+from tests.test_data import TEST_ROUND_ONE
 from tests.test_data import DEFAULT_RESPONSE_FUND_DATA
-from tests.test_data import HARRY_S_BREAKFAST_FUND
-from tests.test_data import ROUNDS_IN_HARRY_S_BREAKFAST_FUND
+from tests.test_data import TEST_FUND_ONE
+from tests.test_data import TEST_ROUNDS_IN_FUND_ONE
 from tests.test_data import TEST_RESPONSE_FUND_DATA
 
 
@@ -39,10 +39,10 @@ def test_single_fund_endpoint(client: Flask, load_test_data):
     initial data.
     """
     host_url = request.host_url
-    url = host_url + "funds/harry-s-breakfast-fund"
+    url = host_url + "funds/fb986cdc-8e02-477a-a7e0-41cf19dd7675"
     api_response_json = client.get(url).json
 
-    expected_data = HARRY_S_BREAKFAST_FUND
+    expected_data = TEST_FUND_ONE
 
     asserts.assert_equal(
         api_response_json,
@@ -59,10 +59,10 @@ def test_all_rounds_in_single_fund_endpoint(client: Flask, load_test_data):
     initial data.
     """
     host_url = request.host_url
-    url = host_url + "funds/harry-s-breakfast-fund/rounds"
+    url = host_url + "funds/fb986cdc-8e02-477a-a7e0-41cf19dd7675/rounds"
     api_response_json = client.get(url).json
 
-    expected_data = ROUNDS_IN_HARRY_S_BREAKFAST_FUND
+    expected_data = TEST_ROUNDS_IN_FUND_ONE
 
     asserts.assert_equal(
         api_response_json,
@@ -79,10 +79,10 @@ def test_single_round_in_single_fund_endpoint(client: Flask, load_test_data):
     initial data.
     """
     host_url = request.host_url
-    url = host_url + "funds/harry-s-breakfast-fund/rounds/brekky"
+    url = host_url + "funds/fb986cdc-8e02-477a-a7e0-41cf19dd7675/rounds/3b1ae9e8-eda4-4910-a5dd-fc144f9a8ba1"
     api_response_json = client.get(url).json
 
-    expected_data = BREKKY_ROUND
+    expected_data = TEST_ROUND_ONE
 
     asserts.assert_equal(
         api_response_json,


### PR DESCRIPTION
The fund store will be our source of truth for the fundamental meta data that represents funds and their associated rounds.  For go live, there's no reason to have a database backing this store as the meta data is simple and we only have one fund and one round to start with.

I have however made a number of changes to the model and the resulting contract that I felt were appropriate when configuring the fund and round for COF:

### Fund model

- fund_id is no longer generated when the fund is created in the DAO from a slug, the id is now explicit and is a guid
- fund_id has been renamed to id
- description and name fields are no longer prefixed with "fund" - the model is about a fund, we don't need that additional information

### Round model

- round_id is no longer generated when the round is created in the DAO as a slug, the id now explicit and is a guid
- round_id has been renamed to id
- round_title has been renamed to title
- eligibility criteria have been removed - eligibility is not relevant for COF and we're temporarily retiring "fund discovery" frontend for MVP launch (it will return, but eligibility criteria are no longer as clear as they were a few months back)
- application URL has also been removed from the model - there is no application URL for COF MVP, applicants will be emailed a link to the starting page for COF which will allow them to start or retrieve and existing application from there

### Round model and weightings (FS-1272)

- Additionally included here is a configuration for the weightings and an adjusted data model with an ID, value and name, represented as an array of objects instead of the previous "reference by name" approach we previously had - happy to discuss this.
- I think even if we switched back to reference by name, this structure SHOULD stay as an array, as in the future, a round could have many (or no) weightings at all for the criteria they represent.