### PR TITLE
Updating round model to include contact details and support availability

### DIFF
--- a/core/data_operations/fund_data.py
+++ b/core/data_operations/fund_data.py
@@ -8,7 +8,6 @@ FUND_DATA = [
     {
         "id": "47aef2f5-3fcb-4d45-acb5-f0152b5f03c4",
         "name": "Community Ownership Fund",
-        "contact_email": "COF@levellingup.gov.uk",
         "description": (
             "The Community Ownership Fund is a £150 million fund over 4 years to support community groups across "
             "England, Wales, Scotland and Northern Ireland to take ownership of assets which are at risk of being "

--- a/core/data_operations/fund_data.py
+++ b/core/data_operations/fund_data.py
@@ -8,6 +8,7 @@ FUND_DATA = [
     {
         "id": "47aef2f5-3fcb-4d45-acb5-f0152b5f03c4",
         "name": "Community Ownership Fund",
+        "short_name": "COF",
         "description": (
             "The Community Ownership Fund is a £150 million fund over 4 years to support community groups across "
             "England, Wales, Scotland and Northern Ireland to take ownership of assets which are at risk of being "

--- a/core/data_operations/round_data.py
+++ b/core/data_operations/round_data.py
@@ -3,11 +3,11 @@
 """
 from core.dummy_dao import RoundDAO
 
-
 ROUND_DATA = [
     {
         "id": "c603d114-5364-4474-a0c4-c41cbf4d3bbd",
         "title": "Round 2 Window 2",
+        "short_name": "R2W2",
         "fund_id": "47aef2f5-3fcb-4d45-acb5-f0152b5f03c4",
         "assessment_criteria_weighting": [
             {
@@ -31,9 +31,9 @@ ROUND_DATA = [
                 "value": 0.10
             }
         ],
-        "opens": "2022-09-01 00:00:01",
-        "deadline": "2023-01-30 00:00:01",
-        "assessment_deadline": "2023-03-20 00:00:01",
+        "opens": "2022-10-04 12:00:00",
+        "deadline": "2023-01-30 11:59:00",
+        "assessment_deadline": "2023-03-30 12:00:00",
         "contact_details": {
             "phone": "",
             "email_address": "COF@levellingup.gov.uk",

--- a/core/data_operations/round_data.py
+++ b/core/data_operations/round_data.py
@@ -34,6 +34,16 @@ ROUND_DATA = [
         "opens": "2022-09-01 00:00:01",
         "deadline": "2023-01-30 00:00:01",
         "assessment_deadline": "2023-03-20 00:00:01",
+        "contact_details": {
+            "phone": "",
+            "email_address": "COF@levellingup.gov.uk",
+            "text_phone": ""
+        },
+        "support_availability": {
+            "time": "9am to 5pm",
+            "days": "Monday to Friday",
+            "closed": "Easter Sunday, Christmas Day, Boxing Day and New Year’s Day"
+        }
     },
 ]
 

--- a/core/data_operations/round_data.py
+++ b/core/data_operations/round_data.py
@@ -13,23 +13,23 @@ ROUND_DATA = [
             {
                 "id": "e2fd30d2-9207-421c-b8b3-c961bcee138b",
                 "name": "Strategic case",
-                "value": 0.30
+                "value": 0.30,
             },
             {
                 "id": "e557773a-74c9-43ee-a52c-88ccae279d08",
                 "name": "Management case",
-                "value": 0.30
+                "value": 0.30,
             },
             {
                 "id": "9e282cdb-6c42-4430-9563-dc4995b59bdd",
                 "name": "Potential to delivery community benefits",
-                "value": 0.30
+                "value": 0.30,
             },
             {
                 "id": "6020db6c-df67-4932-a2f3-2e9dd1934164",
                 "name": "Added value to the community",
-                "value": 0.10
-            }
+                "value": 0.10,
+            },
         ],
         "opens": "2022-10-04 12:00:00",
         "deadline": "2023-01-30 11:59:00",
@@ -37,13 +37,15 @@ ROUND_DATA = [
         "contact_details": {
             "phone": "",
             "email_address": "COF@levellingup.gov.uk",
-            "text_phone": ""
+            "text_phone": "",
         },
         "support_availability": {
             "time": "9am to 5pm",
             "days": "Monday to Friday",
-            "closed": "Easter Sunday, Christmas Day, Boxing Day and New Year’s Day"
-        }
+            "closed": (
+                "Easter Sunday, Christmas Day, Boxing Day and New Year’s Day"
+            ),
+        },
     },
 ]
 

--- a/core/dummy_dao.py
+++ b/core/dummy_dao.py
@@ -1,7 +1,6 @@
 """A dummy DAO implementation. Acts as a template for our
 future implementation.
 """
-from slugify import slugify
 
 
 class FundDAO:
@@ -36,11 +35,7 @@ class RoundDAO:
             round for round in all_round_list if round["fund_id"] == fund_id
         ]
         the_round = next(
-            (
-                round
-                for round in fund_round_list
-                if round["id"] == round_id
-            ),
+            (round for round in fund_round_list if round["id"] == round_id),
             None,
         )
         return the_round

--- a/tests/test_funds.py
+++ b/tests/test_funds.py
@@ -4,11 +4,11 @@ A file containing all tests related to the fund endpoint.
 import asserts
 from flask import Flask
 from flask import request
-from tests.test_data import TEST_ROUND_ONE
 from tests.test_data import DEFAULT_RESPONSE_FUND_DATA
 from tests.test_data import TEST_FUND_ONE
-from tests.test_data import TEST_ROUNDS_IN_FUND_ONE
 from tests.test_data import TEST_RESPONSE_FUND_DATA
+from tests.test_data import TEST_ROUND_ONE
+from tests.test_data import TEST_ROUNDS_IN_FUND_ONE
 
 
 def test_all_funds_endpoint(client: Flask, load_test_data):
@@ -79,7 +79,11 @@ def test_single_round_in_single_fund_endpoint(client: Flask, load_test_data):
     initial data.
     """
     host_url = request.host_url
-    url = host_url + "funds/fb986cdc-8e02-477a-a7e0-41cf19dd7675/rounds/3b1ae9e8-eda4-4910-a5dd-fc144f9a8ba1"
+    url = (
+        host_url
+        + "funds/fb986cdc-8e02-477a-a7e0-41cf19dd7675/"
+        "rounds/3b1ae9e8-eda4-4910-a5dd-fc144f9a8ba1"
+    )
     api_response_json = client.get(url).json
 
     expected_data = TEST_ROUND_ONE

--- a/tests/test_healthcheck.py
+++ b/tests/test_healthcheck.py
@@ -7,9 +7,7 @@ from flask import Flask
 def test_healthchecks_endpoint(client: Flask):
     response = client.get("/healthcheck")
 
-    expected_dict = {"checks":[{"check_flask_running": "OK"}]}
+    expected_dict = {"checks": [{"check_flask_running": "OK"}]}
 
     assert 200 == response.status_code, "Unexpected status code"
     assert expected_dict == response.json, "Unexpected json body"
-
-


### PR DESCRIPTION
We need to be able to easily change/add phone numbers, text phone and email address to the help sections spread throughout authenticator and frontend without having to make lots of content PRs after we go live.

Adding to Round model here to include this information, allowing us to make a single PR to change these details as required.

From a model perspective, opening hours and contact details do belong to a round.