### PR TITLE
FS-1406: add fund short_name to model for use in user friendly application reference

### DIFF
--- a/core/data_operations/fund_data.py
+++ b/core/data_operations/fund_data.py
@@ -8,11 +8,13 @@ FUND_DATA = [
     {
         "id": "47aef2f5-3fcb-4d45-acb5-f0152b5f03c4",
         "name": "Community Ownership Fund",
+        "short_name": "COF",
         "contact_email": "COF@levellingup.gov.uk",
         "description": (
-            "The Community Ownership Fund is a £150 million fund over 4 years to support community groups across "
-            "England, Wales, Scotland and Northern Ireland to take ownership of assets which are at risk of being "
-            "lost to the community."
+            "The Community Ownership Fund is a £150 million fund over 4 years"
+            " to support community groups across England, Wales, Scotland and"
+            " Northern Ireland to take ownership of assets which are at risk"
+            " of being lost to the community."
         ),
     },
 ]


### PR DESCRIPTION
add fund `short_name` to model for use in user friendly application reference