### PR TITLE
FS-1677: pass through github sha

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -10,6 +10,7 @@ applications:
     FLASK_ENV: dev
     # Sentry DSN is OK to be public see: https://docs.sentry.io/product/sentry-basics/dsn-explainer/#dsn-utilization
     SENTRY_DSN: https://5ea1346b1c1b4dd8af0c95435ca77945@o1432034.ingest.sentry.io/4503903486148608
+    GITHUB_SHA: ((GITHUB_SHA))
   health-check-http-endpoint: /healthcheck
   health-check-type: http
 
@@ -22,5 +23,6 @@ applications:
     FLASK_ENV: test
     # Sentry DSN is OK to be public see: https://docs.sentry.io/product/sentry-basics/dsn-explainer/#dsn-utilization
     SENTRY_DSN: https://5ea1346b1c1b4dd8af0c95435ca77945@o1432034.ingest.sentry.io/4503903486148608
+    GITHUB_SHA: ((GITHUB_SHA))
   health-check-http-endpoint: /healthcheck
   health-check-type: http


### PR DESCRIPTION
Implements utils feature to pass through the `GITHUB_SHA` for Sentry releases.