### PR TITLE
FS-2147: add config option to change application deadline

### DIFF
--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -1,8 +1,10 @@
 """Flask configuration."""
 import logging
 from os import environ
+from os import getenv
 from pathlib import Path
 
+from distutils.util import strtobool
 from fsd_utils import configclass
 
 
@@ -20,3 +22,4 @@ class DefaultConfig(object):
     # Frontend
     STATIC_FOLDER = "static"
     TEMPLATES_FOLDER = "templates"
+    FORCE_OPEN = strtobool(getenv("FORCE_OPEN", "False"))

--- a/core/data_operations/round_data.py
+++ b/core/data_operations/round_data.py
@@ -1,6 +1,7 @@
 """
     Round configuration
 """
+from config import Config
 from core.dummy_dao import RoundDAO
 
 
@@ -37,7 +38,9 @@ def get_round_data(language):
                 },
             ],
             "opens": "2022-10-04 12:00:00",
-            "deadline": "2022-12-14 11:59:00",
+            "deadline": "2022-12-14 11:59:00"
+            if not Config.FORCE_OPEN
+            else "2024-12-31 11:59:00",
             "assessment_deadline": "2023-03-30 12:00:00",
             "contact_details": {
                 "phone": "",


### PR DESCRIPTION
Add config option to extend deadline.
(Plan is to enable this on UAT only to re-open applications for user research)