### PR TITLE
adding ability to get data using short name

### DIFF
--- a/core/fund_round_dao.py
+++ b/core/fund_round_dao.py
@@ -22,6 +22,16 @@ class FundDAO:
         for fund in fund_data:
             self.create(fund)
 
+    def search_by_short_name(self, short_name):
+        return next(
+            (
+                fund
+                for fund in self.get_all()
+                if str.upper(fund["short_name"]) == str.upper(short_name)
+            ),
+            None,
+        )
+
 
 class RoundDAO:
     """A dummy interface to use instead of a database ORM."""

--- a/core/funds.py
+++ b/core/funds.py
@@ -2,6 +2,7 @@
 Python functions to return responses of funds from our GET requests
 """
 from core.data_operations import fund_data
+from distutils.util import strtobool
 from flask import request
 
 
@@ -31,8 +32,9 @@ def get_fund(fund_id: str):
     """
     language = request.args.get("language")
     fund_data.FUNDS_DAO.load_data(fund_data.get_fund_data(language))
-    use_short_name = request.args.get("use_short_name")
-    if use_short_name == "true":
+    short_name_arg = request.args.get("use_short_name")
+    use_short_name = short_name_arg and strtobool(short_name_arg)
+    if use_short_name:
         fund_search = fund_data.FUNDS_DAO.search_by_short_name(fund_id)
     else:
         fund_search = fund_data.FUNDS_DAO.get_one(fund_id, language)
@@ -42,6 +44,6 @@ def get_fund(fund_id: str):
         return {
             "code": 404,
             "message": f"fund_id : {fund_id} cannot be found"
-            if use_short_name != "true"
+            if not use_short_name
             else f"short_name {fund_id} cannot be found",
         }, 404

--- a/core/funds.py
+++ b/core/funds.py
@@ -31,11 +31,17 @@ def get_fund(fund_id: str):
     """
     language = request.args.get("language")
     fund_data.FUNDS_DAO.load_data(fund_data.get_fund_data(language))
-    fund_search = fund_data.FUNDS_DAO.get_one(fund_id, language)
+    use_short_name = request.args.get("use_short_name")
+    if use_short_name == "true":
+        fund_search = fund_data.FUNDS_DAO.search_by_short_name(fund_id)
+    else:
+        fund_search = fund_data.FUNDS_DAO.get_one(fund_id, language)
     if isinstance(fund_search, dict):
         return fund_search, 200
     else:
         return {
             "code": 404,
-            "message": f"fund_id : {fund_id} cannot be found.",
+            "message": f"fund_id : {fund_id} cannot be found"
+            if use_short_name != "true"
+            else f"short_name {fund_id} cannot be found",
         }, 404

--- a/core/rounds.py
+++ b/core/rounds.py
@@ -1,6 +1,7 @@
 """
 Python functions to return responses of rounds from our GET requests
 """
+from core.data_operations import fund_data
 from core.data_operations import round_data
 from flask import request
 
@@ -16,13 +17,25 @@ def get_rounds_for_fund(fund_id: str):
     """
     language = request.args.get("language")
     round_data.ROUNDS_DAO.load_data(round_data.get_round_data(language))
-    rounds = round_data.ROUNDS_DAO.get_all_for_fund(fund_id)
+    fund_data.FUNDS_DAO.load_data(fund_data.get_fund_data(language))
+    use_short_name = request.args.get("use_short_name")
+    rounds = []
+    if use_short_name == "true":
+        fund_search = fund_data.FUNDS_DAO.search_by_short_name(fund_id)
+        if fund_search:
+            rounds = round_data.ROUNDS_DAO.get_all_for_fund(fund_search["id"])
+    else:
+        rounds = round_data.ROUNDS_DAO.get_all_for_fund(fund_id)
+
     if len(rounds) > 0:
         return rounds, 200
     else:
         return {
             "code": 404,
-            "message": f"Rounds for fund_id : {fund_id} cannot be found.",
+            "message": (
+                f"Rounds for fund_id : {fund_id} cannot be found"
+                f" (use_short_name: {use_short_name})"
+            ),
         }, 404
 
 

--- a/core/rounds.py
+++ b/core/rounds.py
@@ -3,6 +3,7 @@ Python functions to return responses of rounds from our GET requests
 """
 from core.data_operations import fund_data
 from core.data_operations import round_data
+from distutils.util import strtobool
 from flask import request
 
 
@@ -18,9 +19,10 @@ def get_rounds_for_fund(fund_id: str):
     language = request.args.get("language")
     round_data.ROUNDS_DAO.load_data(round_data.get_round_data(language))
     fund_data.FUNDS_DAO.load_data(fund_data.get_fund_data(language))
-    use_short_name = request.args.get("use_short_name")
+    short_name_arg = request.args.get("use_short_name")
+    use_short_name = short_name_arg and strtobool(short_name_arg)
     rounds = []
-    if use_short_name == "true":
+    if use_short_name:
         fund_search = fund_data.FUNDS_DAO.search_by_short_name(fund_id)
         if fund_search:
             rounds = round_data.ROUNDS_DAO.get_all_for_fund(fund_search["id"])
@@ -32,10 +34,9 @@ def get_rounds_for_fund(fund_id: str):
     else:
         return {
             "code": 404,
-            "message": (
-                f"Rounds for fund_id : {fund_id} cannot be found"
-                f" (use_short_name: {use_short_name})"
-            ),
+            "message": f"fund_id : {fund_id} cannot be found"
+            if not use_short_name
+            else f"short_name {fund_id} cannot be found",
         }, 404
 
 

--- a/openapi/api.yml
+++ b/openapi/api.yml
@@ -74,6 +74,11 @@ paths:
           in: query
           schema:
             type: string
+        - name: use_short_name
+          in: query
+          schema:
+            type: boolean
+          required: false
       responses:
         200:
           description: "If the fund exists then the data is returned."
@@ -101,6 +106,11 @@ paths:
           schema:
             type: string
           required: true
+        - name: use_short_name
+          in: query
+          schema:
+            type: boolean
+          required: false
       responses:
         200:
           description: A list of rounds matching the given fund ID.

--- a/tests/test_cof_data.py
+++ b/tests/test_cof_data.py
@@ -16,7 +16,6 @@ class MockRequest_en:
 
 
 def test_get_cof_r2w3(mocker, monkeypatch):
-
     monkeypatch.setattr(
         "core.rounds.request",
         MockRequest_en(),
@@ -24,6 +23,7 @@ def test_get_cof_r2w3(mocker, monkeypatch):
     result = get_round(
         CommonConfig.COF_FUND_ID, CommonConfig.COF_ROUND_2_W3_ID
     )
+
     assert "Round 2 Window 3" == result[0]["title"]
     assert "Monday to Friday" == result[0]["support_availability"]["days"]
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -5,11 +5,13 @@ TEST_FUND_DATA = [
         "id": "fb986cdc-8e02-477a-a7e0-41cf19dd7675",
         "name": "English fund 1",
         "description": "Test fund description 1",
+        "short_name": "FUND1",
     },
     {
         "id": "e356c266-68a8-4000-ad95-6e4d961f65b4",
         "name": "English fund 2",
         "description": "Test fund description 2",
+        "short_name": "FUND2",
     },
 ]
 

--- a/tests/test_funds.py
+++ b/tests/test_funds.py
@@ -21,7 +21,7 @@ def test_all_funds_endpoint(client: Flask, load_test_data):
     api_response_json = client.get(url).json
 
     assert 3 == len(api_response_json)
-    assert "COF" == api_response_json[2]["short_name"]
+    assert "COF" in [f["short_name"] for f in api_response_json]
 
 
 def test_single_fund_endpoint(client: Flask, load_test_data):

--- a/tests/test_funds.py
+++ b/tests/test_funds.py
@@ -86,3 +86,29 @@ def test_single_round_in_single_fund_endpoint(client: Flask, load_test_data):
         expected_data,
         msg_fmt="/funds didnt return the expected response, {msg}",
     )
+
+
+def test_get_fund_by_short_name(client, load_test_data):
+    host_url = request.host_url
+    expected_data = TEST_FUND_ONE
+
+    url = (
+        host_url
+        + "funds/fb986cdc-8e02-477a-a7e0-41cf19dd7675?use_short_name=false"
+    )
+    api_response_json = client.get(url).json
+
+    assert api_response_json == expected_data
+
+    url = (
+        host_url
+        + "funds/fb986cdc-8e02-477a-a7e0-41cf19dd7675?use_short_name=true"
+    )
+    response = client.get(url)
+
+    assert 404 == response.status_code
+
+    url = host_url + "funds/FUND1?use_short_name=true"
+    api_response_json = client.get(url).json
+
+    assert api_response_json == expected_data


### PR DESCRIPTION
Updated the /funds/<fund_id> and /funds/<fund_id>/rounds/ endpoints to allow lookup via the short name of the fund if `use_short_name=true` is present in the querystring.

To do:

- Update the /funds/<fund_id>/rounds/<round_id> endpoint to work with short names as well for consistency??