### PR TITLE
Updating NSTF R2 deadline date

### DIFF
--- a/config/fund_loader_config/night_shelter/ns_r2.py
+++ b/config/fund_loader_config/night_shelter/ns_r2.py
@@ -174,7 +174,7 @@ round_config = [
         "title_json": {"en": "Round 2", "cy": ""},
         "short_name": "R2",
         "opens": "2023-06-07 12:00:00",
-        "deadline": "2023-07-05 11:59:00",
+        "deadline": "2023-07-07 11:59:00",
         "assessment_deadline": "2023-08-09 12:00:00",
         "prospectus": NIGHT_SHELTER_PROSPECTS_LINK,
         "privacy_notice": "https://www.gov.uk/guidance/night-shelter-transformation-fund-2022-2025-privacy-notice",


### PR DESCRIPTION
Updating the deadline date to be 7th July 2023. Already updated direct in DBs in all envs, updating script now for audit and history purposes.

