### PR TITLE
FS-3184: Add "All uploaded documents" functionality

### DIFF
--- a/db/migrations/versions/108033941f74_.py
+++ b/db/migrations/versions/108033941f74_.py
@@ -1,0 +1,55 @@
+"""empty message
+
+Revision ID: 108033941f74
+Revises: 6928bebf9d54
+Create Date: 2023-07-11 14:04:01.128224
+
+"""
+import sqlalchemy
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "108033941f74"
+down_revision = "6928bebf9d54"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("fund", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "all_uploaded_documents_section_available", sa.Boolean(), nullable=True
+            )
+        )
+
+    connection = op.get_bind()
+    connection.execute(
+        sqlalchemy.text(
+            """
+            UPDATE fund
+            SET all_uploaded_documents_section_available = false
+            """
+        )
+    )
+
+    connection.execute(
+        sqlalchemy.text(
+            """
+            UPDATE fund
+            SET all_uploaded_documents_section_available = true
+            WHERE short_name = 'COF'
+            """
+        )
+    )
+
+    with op.batch_alter_table("fund", schema=None) as batch_op:
+        batch_op.alter_column(
+            "all_uploaded_documents_section_available", nullable=False
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("fund", schema=None) as batch_op:
+        batch_op.drop_column("all_uploaded_documents_section_available")

--- a/db/models/fund.py
+++ b/db/models/fund.py
@@ -35,3 +35,9 @@ class Fund(BaseModel):
     )
     rounds: Mapped[List["Round"]] = relationship("Round")
     welsh_available = Column("welsh_available", Boolean, default=False, nullable=False)
+    all_uploaded_documents_section_available = Column(
+        "all_uploaded_documents_section_available",
+        Boolean,
+        default=False,
+        nullable=False,
+    )


### PR DESCRIPTION
### Change description

- Add `all_uploaded_documents_section_available` to funds
- Determines whether the "all_uploaded_documents" psuedo-theme is available for a fund on assessment
- Add migration script, COF has this feature, and NSTF does not

---

- [x] Unit tests and other appropriate tests added or updated
- [x] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines

### Related 

- https://github.com/communitiesuk/funding-service-design-assessment-store/pull/227
- https://github.com/communitiesuk/funding-service-design-assessment/pull/319