### PR TITLE
FS-3375: Fix COFR3W2 filename references in import script

### DIFF
--- a/config/fund_loader_config/cof/cof_r3.py
+++ b/config/fund_loader_config/cof/cof_r3.py
@@ -279,8 +279,8 @@ cof_r3w2_sections = [
             "cy": "1.1 Gwybodaeth am y sefydliad",
         },
         "form_name_json": {
-            "en": "organisation-information-cof-r3-w1",
-            "cy": "gwybodaeth-am-y-sefydliad-cof-r3-w1",
+            "en": "organisation-information-cof-r3-w2",
+            "cy": "gwybodaeth-am-y-sefydliad-cof-r3-w2",
         },
         "tree_path": f"{APPLICATION_BASE_PATH_COF_R3_W2}.1.1",
     },
@@ -290,8 +290,8 @@ cof_r3w2_sections = [
             "cy": "1.2 Gwybodaeth am yr ymgeisydd",
         },
         "form_name_json": {
-            "en": "applicant-information-cof-r3-w1",
-            "cy": "gwybodaeth-am-yr-ymgeisydd-cof-r3-w1",
+            "en": "applicant-information-cof-r3-w2",
+            "cy": "gwybodaeth-am-yr-ymgeisydd-cof-r3-w2",
         },
         "tree_path": f"{APPLICATION_BASE_PATH_COF_R3_W2}.1.2",
     },
@@ -308,8 +308,8 @@ cof_r3w2_sections = [
             "cy": "2.1 Gwybodaeth am y prosiect",
         },
         "form_name_json": {
-            "en": "project-information-cof-r3-w1",
-            "cy": "gwybodaeth-am-y-prosiect-cof-r3-w1",
+            "en": "project-information-cof-r3-w2",
+            "cy": "gwybodaeth-am-y-prosiect-cof-r3-w2",
         },
         "tree_path": f"{APPLICATION_BASE_PATH_COF_R3_W2}.2.1",
     },
@@ -320,7 +320,7 @@ cof_r3w2_sections = [
         },
         "form_name_json": {
             "en": "asset-information-cof-r3-w2",
-            "cy": "gwybodaeth-am-yr-ased-cof-r3-w1",
+            "cy": "gwybodaeth-am-yr-ased-cof-r3-w2",
         },
         "tree_path": f"{APPLICATION_BASE_PATH_COF_R3_W2}.2.2",
     },
@@ -332,8 +332,8 @@ cof_r3w2_sections = [
     {
         "section_name": {"en": "3.1 Community use", "cy": "3.1 Defnydd cymunedol"},
         "form_name_json": {
-            "en": "community-use-cof-r3-w1",
-            "cy": "defnydd-cymunedol-cof-r3-w1",
+            "en": "community-use-cof-r3-w2",
+            "cy": "defnydd-cymunedol-cof-r3-w2",
         },
         "tree_path": f"{APPLICATION_BASE_PATH_COF_R3_W2}.3.1",
     },
@@ -343,16 +343,16 @@ cof_r3w2_sections = [
             "cy": "3.2 Ymgysylltu â'r gymuned",
         },
         "form_name_json": {
-            "en": "community-engagement-cof-r3-w1",
-            "cy": "ymgysylltiad-cymunedol-cof-r3-w1",
+            "en": "community-engagement-cof-r3-w2",
+            "cy": "ymgysylltiad-cymunedol-cof-r3-w2",
         },
         "tree_path": f"{APPLICATION_BASE_PATH_COF_R3_W2}.3.2",
     },
     {
         "section_name": {"en": "3.3 Local support", "cy": "3.3 Cefnogaeth leol"},
         "form_name_json": {
-            "en": "local-support-cof-r3-w1",
-            "cy": "cefnogaeth-leol-cof-r3-w1",
+            "en": "local-support-cof-r3-w2",
+            "cy": "cefnogaeth-leol-cof-r3-w2",
         },
         "tree_path": f"{APPLICATION_BASE_PATH_COF_R3_W2}.3.3",
     },
@@ -362,8 +362,8 @@ cof_r3w2_sections = [
             "cy": "3.4 Buddion i'r gymuned",
         },
         "form_name_json": {
-            "en": "community-benefits-cof-r3-w1",
-            "cy": "buddion-cymunedol-cof-r3-w1",
+            "en": "community-benefits-cof-r3-w2",
+            "cy": "buddion-cymunedol-cof-r3-w2",
         },
         "tree_path": f"{APPLICATION_BASE_PATH_COF_R3_W2}.3.4",
     },
@@ -373,8 +373,8 @@ cof_r3w2_sections = [
             "cy": "3.5 Cynaliadwyedd amgylcheddol",
         },
         "form_name_json": {
-            "en": "environmental-sustainability-cof-r3-w1",
-            "cy": "cynaliadwyedd-amgylcheddol-cof-r3-w1",
+            "en": "environmental-sustainability-cof-r3-w2",
+            "cy": "cynaliadwyedd-amgylcheddol-cof-r3-w2",
         },
         "tree_path": f"{APPLICATION_BASE_PATH_COF_R3_W2}.3.5",
     },
@@ -390,28 +390,28 @@ cof_r3w2_sections = [
         },
         "form_name_json": {
             "en": "funding-required-cof-r3-w2",
-            "cy": "cyllid-sydd-ei-angen-cof-r3-w1",
+            "cy": "cyllid-sydd-ei-angen-cof-r3-w2",
         },
         "tree_path": f"{APPLICATION_BASE_PATH_COF_R3_W2}.4.1",
     },
     {
         "section_name": {"en": "4.2 Feasibility", "cy": "4.2 Dichonoldeb"},
         "form_name_json": {
-            "en": "feasibility-cof-r3-w1",
-            "cy": "dichonoldeb-cof-r3-w1",
+            "en": "feasibility-cof-r3-w2",
+            "cy": "dichonoldeb-cof-r3-w2",
         },
         "tree_path": f"{APPLICATION_BASE_PATH_COF_R3_W2}.4.2",
     },
     {
         "section_name": {"en": "4.3 Risk", "cy": "4.3 Risg"},
-        "form_name_json": {"en": "risk-cof-r3-w1", "cy": "risg-cof-r3-w1"},
+        "form_name_json": {"en": "risk-cof-r3-w2", "cy": "risg-cof-r3-w2"},
         "tree_path": f"{APPLICATION_BASE_PATH_COF_R3_W2}.4.3",
     },
     {
         "section_name": {"en": "4.4 Operational costs", "cy": "4.4 Costau gweithredol"},
         "form_name_json": {
             "en": "operational-costs-cof-r3-w2",
-            "cy": "costau-gweithredol-cof-r3-w1",
+            "cy": "costau-gweithredol-cof-r3-w2",
         },
         "tree_path": f"{APPLICATION_BASE_PATH_COF_R3_W2}.4.4",
     },
@@ -421,8 +421,8 @@ cof_r3w2_sections = [
             "cy": "4.5 Sgiliau ac Adnoddau",
         },
         "form_name_json": {
-            "en": "skills-and-resources-cof-r3-w1",
-            "cy": "sgiliau-ac-adnoddau-cof-r3-w1",
+            "en": "skills-and-resources-cof-r3-w2",
+            "cy": "sgiliau-ac-adnoddau-cof-r3-w2",
         },
         "tree_path": f"{APPLICATION_BASE_PATH_COF_R3_W2}.4.5",
     },
@@ -432,8 +432,8 @@ cof_r3w2_sections = [
             "cy": "4.6 Cynrychiolaeth gymunedol",
         },
         "form_name_json": {
-            "en": "community-representation-cof-r3-w1",
-            "cy": "cynrychiolaeth-gymunedol-cof-r3-w1",
+            "en": "community-representation-cof-r3-w2",
+            "cy": "cynrychiolaeth-gymunedol-cof-r3-w2",
         },
         "tree_path": f"{APPLICATION_BASE_PATH_COF_R3_W2}.4.6",
     },
@@ -443,8 +443,8 @@ cof_r3w2_sections = [
             "cy": "4.7 Cynhwysiant ac Integreiddio",
         },
         "form_name_json": {
-            "en": "inclusiveness-and-integration-cof-r3-w1",
-            "cy": "cynhwysiant-ac-integreiddio-cof-r3-w1",
+            "en": "inclusiveness-and-integration-cof-r3-w2",
+            "cy": "cynhwysiant-ac-integreiddio-cof-r3-w2",
         },
         "tree_path": f"{APPLICATION_BASE_PATH_COF_R3_W2}.4.7",
     },
@@ -454,8 +454,8 @@ cof_r3w2_sections = [
             "cy": "4.8 Lanlwythwch y cynllun busnes",
         },
         "form_name_json": {
-            "en": "upload-business-plan-cof-r3-w1",
-            "cy": "lanlwythwch-y-cynllun-busnes-cof-r3-w1",
+            "en": "upload-business-plan-cof-r3-w2",
+            "cy": "lanlwythwch-y-cynllun-busnes-cof-r3-w2",
         },
         "tree_path": f"{APPLICATION_BASE_PATH_COF_R3_W2}.4.8",
     },
@@ -472,8 +472,8 @@ cof_r3w2_sections = [
             "cy": "5.1 Cymhwystra'r prosiect",
         },
         "form_name_json": {
-            "en": "project-qualifications-cof-r3-w1",
-            "cy": "cymhwysedd-y-prosiect-cof-r3-w1",
+            "en": "project-qualifications-cof-r3-w2",
+            "cy": "cymhwysedd-y-prosiect-cof-r3-w2",
         },
         "tree_path": f"{APPLICATION_BASE_PATH_COF_R3_W2}.5.1",
     },
@@ -484,8 +484,8 @@ cof_r3w2_sections = [
     {
         "section_name": {"en": "6.1 Declarations", "cy": "6.1 Datganiadau"},
         "form_name_json": {
-            "en": "declarations-cof-r3-w1",
-            "cy": "cadarnhadau-terfynol-cof-r3-w1",
+            "en": "declarations-cof-r3-w2",
+            "cy": "cadarnhadau-terfynol-cof-r3-w2",
         },
         "tree_path": f"{APPLICATION_BASE_PATH_COF_R3_W2}.6.1",
     },


### PR DESCRIPTION
- Was previously referencing old form names
- Changed to r3w2 form names

Deleted old script inserts from database manually on test/uat:

```sql
DELETE FROM form_name 
WHERE section_id IN (SELECT id FROM section WHERE round_id = '6af19a5e-9cae-4f00-9194-cf10d2d7c8a7');
```

```sql
DELETE FROM section WHERE round_id = '6af19a5e-9cae-4f00-9194-cf10d2d7c8a7';
```