### PR TITLE
FS-3207: Fixing manual deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   test_and_deploy:
-    if: ${{ !github.event.inputs.copilot }}
+    if: ${{github.event.inputs.copilot != 'true'}}
     uses: communitiesuk/funding-design-service-workflows/.github/workflows/deploy.yml@main
     with:
       app_name: ${{ github.event.repository.name }}
@@ -50,7 +50,7 @@ jobs:
       owner: ${{ github.repository_owner }}
       application: funding-design-service-fund-store
   pre_deploy_tests:
-    if: ${{ github.event.inputs.copilot }}
+    if: ${{github.event.inputs.copilot == 'true'}}
     secrets:
       E2E_PAT: ${{secrets.E2E_PAT}}
     uses: communitiesuk/funding-design-service-workflows/.github/workflows/pre-deploy.yml@main
@@ -58,7 +58,7 @@ jobs:
       # Note - no db-name, so defaults to postgres_db
       postgres_unit_testing: true
   copilot_build:
-    if: ${{ github.event.inputs.copilot }}
+    if: ${{github.event.inputs.copilot == 'true'}}
     needs: [pre_deploy_tests, paketo_build]
     concurrency: deploy-${{ inputs.environment || 'test' }}
     permissions:


### PR DESCRIPTION
### Change description

At the moment, when manually run, copilot runs by default. There is currently no copilot resources to run _against_,. so with a manual run the run will go down the copilot path every time. This commit fixes that with proper verification of parameters passed

- [ N/A ] Unit tests and other appropriate tests added or updated
- [ N/A ] README and other documentation has been updated / added (if needed)
- [ X ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")