### PR TITLE
fs-3704 fixing max words by adding more field types

### DIFF
--- a/scripts/all_questions/metadata_utils.py
+++ b/scripts/all_questions/metadata_utils.py
@@ -14,6 +14,8 @@ from scripts.all_questions.read_forms import increment_lowest_in_hierarchy
 from scripts.all_questions.read_forms import remove_lowest_in_hierarchy
 from scripts.all_questions.read_forms import strip_leading_numbers
 
+FIELD_TYPES_WITH_MAX_WORDS=["freetextfield", "multilinetextfield"]
+
 
 def get_all_child_nexts(page: dict, child_nexts: list, all_pages: dict):
     """Recursively builds a list of everything that could come next from this page,
@@ -298,7 +300,7 @@ def determine_title_and_text_for_component(
             child_title, child_text = determine_title_and_text_for_component(
                 child, include_html_components, form_lists, is_child=True
             )
-            if child["type"].casefold() == "multilinetextfield":
+            if child["type"].casefold() in FIELD_TYPES_WITH_MAX_WORDS:
                 first_column_title = component["options"]["columnTitles"][0].casefold()
                 text.append(
                     f"{child_title} (Max {child['options']['maxWords']} words per"
@@ -325,8 +327,9 @@ def determine_title_and_text_for_component(
         text = []
         extract_from_html(soup, text)
         update_wording_for_multi_input_fields(text)
-        if component["type"].casefold() == "multilinetextfield" and not is_child:
-            text.append(f"(Max {component['options']['maxWords']} words)")
+
+    if component["type"].casefold() in FIELD_TYPES_WITH_MAX_WORDS and not is_child:
+        text.append(f"(Max {component['options']['maxWords']} words)")
 
     if "list" in component:
         # include available options for lists

--- a/scripts/all_questions/metadata_utils.py
+++ b/scripts/all_questions/metadata_utils.py
@@ -14,7 +14,7 @@ from scripts.all_questions.read_forms import increment_lowest_in_hierarchy
 from scripts.all_questions.read_forms import remove_lowest_in_hierarchy
 from scripts.all_questions.read_forms import strip_leading_numbers
 
-FIELD_TYPES_WITH_MAX_WORDS=["freetextfield", "multilinetextfield"]
+FIELD_TYPES_WITH_MAX_WORDS = ["freetextfield", "multilinetextfield"]
 
 
 def get_all_child_nexts(page: dict, child_nexts: list, all_pages: dict):

--- a/tests/test_generate_all_questions.py
+++ b/tests/test_generate_all_questions.py
@@ -404,7 +404,8 @@ def test_build_components_bullets_in_hint():
     )
     components = build_components_from_page(page_json, include_html_components=False)
     assert len(components) == 1
-    assert len(components[0]["text"]) == 2
+    assert len(components[0]["text"]) == 3
+    assert components[0]["text"][2] == "(Max 250 words)"
     assert len(components[0]["text"][1]) == 3
 
 


### PR DESCRIPTION
### Change description
FS-3704 identifies that the max words info was missing for some fields. I've added the missing field types and also included it when there isn't a hint for that question.

- [x] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### Screenshots of UI changes (if applicable)
![Screenshot 2023-10-27 at 13 09 57](https://github.com/communitiesuk/funding-service-design-fund-store/assets/1729216/cfc6c5a8-b39b-4e70-aa93-62e96083096f)
![Screenshot 2023-10-27 at 13 10 07](https://github.com/communitiesuk/funding-service-design-fund-store/assets/1729216/d6770325-a8fa-4853-a7bc-c43450ee802f)
