### PR TITLE
added guidance url for dpif fund

### DIFF
--- a/config/fund_loader_config/digital_planning/dpi_r2.py
+++ b/config/fund_loader_config/digital_planning/dpi_r2.py
@@ -148,7 +148,10 @@ round_config = [
         "feedback_link": "",
         "project_name_field_id": "JAAhRP",
         "application_guidance": DPI_APPLICATION_GUIDANCE,
-        "guidance_url": "",
+        "guidance_url": (
+            "https://docs.google.com/document/d/1cF5eKphoBWEUe0Zv5HBwv0R3n1svCk16kUFRJhKnIQY"
+            "/edit#heading=h.b0vrhm5gih2k"
+        ),
         "all_uploaded_documents_section_available": False,
         "application_fields_download_available": False,
         "display_logo_on_pdf_exports": False,

--- a/scripts/data_updates/FS-3749_dpif_guidance_url.py
+++ b/scripts/data_updates/FS-3749_dpif_guidance_url.py
@@ -1,0 +1,37 @@
+import config.fund_loader_config.digital_planning.dpi_r2 as dpi_r2
+from db import db
+from db.models.round import Round
+from flask import current_app
+from sqlalchemy import update
+
+
+def update_rounds_with_links(rounds):
+    for round in rounds:
+        current_app.logger.warning(f"\tRound: {round['short_name']} ({round['id']})")
+        if round.get("guidance_url"):
+            current_app.logger.warning("\t\tUpdating guidance_url")
+            stmt = (
+                update(Round)
+                .where(Round.id == round["id"])
+                .values(
+                    guidance_url=round["guidance_url"],
+                )
+            )
+
+            db.session.execute(stmt)
+        else:
+            current_app.logger.warning("\t\tNo guidance_url defined")
+    db.session.commit()
+
+
+def main() -> None:
+    current_app.logger.warning("Updating guidance_url for DPIF R2")
+    update_rounds_with_links(dpi_r2.round_config)
+    current_app.logger.warning("Updates complete")
+
+
+if __name__ == "__main__":
+    from app import app
+
+    with app.app_context():
+        main()


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/FS-3749

### Description
Assessment criteria link added for DPIF assessors

### How to test
To run the script, find the container ID for the fund-store and execute
`docker exec -it <fund_store_container_id> python -m scripts.data_updates.FS-3749_dpif_guidance_url`

To run on cloud foundry, use `cf run-task`
`cf run-task funding-service-design-fund-store-test --command "python -m scripts.data_updates.FS-3749_dpif_guidance_url"`

### Screenshots of UI changes (if applicable)
