### PR TITLE
FS-4179: Remove redundant link from instructions

### DIFF
--- a/config/fund_loader_config/cof/eoi.py
+++ b/config/fund_loader_config/cof/eoi.py
@@ -130,9 +130,7 @@ round_config_eoi = [
         "support_days": "Monday to Friday",
         "instructions": (
             "You must complete this Expression of Interest (EOI) form if you"
-            " are interested in applying for the Community Ownership Fund (COF). <a"
-            ' href="https://www.gov.uk/government/publications/community-ownership-fund-prospectus"'
-            " Read the fund's prospectus before you start.</a>"
+            " are interested in applying for the Community Ownership Fund (COF)."
         ),
         "feedback_link": (
             "https://forms.office.com/Pages/ResponsePage.aspx?id="


### PR DESCRIPTION
### Change description

- Remove erroneous and redundant anchor tag from instructions
- The anchor was missing the initial `>` on the opening of the tag
- The anchor is hardcoded on the front-end [here](https://github.com/communitiesuk/funding-service-design-fund-store/pull/new/tferns-fs-4179-accessibility), so this was duplicated anyways
---

- [x] Unit tests and other appropriate tests added or updated
- [x] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines 

### Screenshots of UI changes (if applicable)

![image](https://github.com/communitiesuk/funding-service-design-fund-store/assets/117724519/6c0e3a1c-31c0-40b1-b30e-fa80a0f11e49)

