### PR TITLE
Updated script to work with setting assessment_start_date to blank

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,21 @@ Further details on the fund/round loader scripts, and how to load data for a spe
 This script allows you to open/close rounds using their dates to test different functionality as needed
 
 ```bash
-    docker exec -ti $(docker ps -qf "name=fund-store") python -m scripts.amend_round_dates --round_id c603d114-5364-4474-a0c4-c41cbf4d3bbd --deadline_date "2023-03-30 12:00:00"
+docker exec -ti $(docker ps -qf "name=fund-store") python -m scripts.amend_round_dates -q update-round-dates --round_id c603d114-5364-4474-a0c4-c41cbf4d3bbd --application_deadline "2023-03-30 12:00:00"
 
-
-    docker exec -ti $(docker ps -qf "name=fund-store") python -m scripts.amend_round_dates --round_id c603d114-5364-4474-a0c4-c41cbf4d3bbd --opens_date "2022-10-04 12:00:00" --deadline_date "2022-12-14 11:59:00" --assessment_deadline_date "2023-03-30 12:00:00"
+docker exec -ti $(docker ps -qf "name=fund-store") python -m scripts.amend_round_dates -q update-round-dates -r COF_R3W3 -o "2022-10-04 12:00:00" -d "2022-12-14 11:59:00" -ad "2023-03-30 12:00:00" -as NONE
+```
+For an interactive prompt where you can supply (or leave unchanged) all dates:
+```bash
+docker exec -ti $(docker ps -qf "name=fund-store") python -m scripts.amend_round_dates update-round-dates
+```
+To reset the dates for a round to those in the fund loader config:
+```bash
+docker exec -ti $(docker ps -qf "name=fund-store") python -m scripts.amend_round_dates -q reset-round-dates -r COF_R4W1
+```
+And with an interactive prompt:
+```bash
+docker exec -ti $(docker ps -qf "name=fund-store") python -m scripts.amend_round_dates reset-round-dates
 ```
 
 # Testing

--- a/README.md
+++ b/README.md
@@ -69,12 +69,14 @@ If running with the docker compose setup:
 Further details on the fund/round loader scripts, and how to load data for a specific fund or round can be found [here](https://dluhcdigital.atlassian.net/wiki/spaces/FS/pages/40337455/Adding+or+updating+fund+and+round+data)
 
 ## Amending round dates
-This script allows you to open/close rounds using their dates to test different functionality as needed
+This script allows you to open/close rounds using their dates to test different functionality as needed. You can also use the keywords 'PAST', 'FUTURE' and 'UNCHANGED' to save typing dates.
 
 ```bash
 docker exec -ti $(docker ps -qf "name=fund-store") python -m scripts.amend_round_dates -q update-round-dates --round_id c603d114-5364-4474-a0c4-c41cbf4d3bbd --application_deadline "2023-03-30 12:00:00"
 
 docker exec -ti $(docker ps -qf "name=fund-store") python -m scripts.amend_round_dates -q update-round-dates -r COF_R3W3 -o "2022-10-04 12:00:00" -d "2022-12-14 11:59:00" -ad "2023-03-30 12:00:00" -as NONE
+
+docker exec -ti $(docker ps -qf "name=fund-store") python -m scripts.amend_round_dates -q update-round-dates -r COF_R3W3 -o PAST -d FUTURE
 ```
 For an interactive prompt where you can supply (or leave unchanged) all dates:
 ```bash

--- a/scripts/amend_round_dates.py
+++ b/scripts/amend_round_dates.py
@@ -161,7 +161,7 @@ def update_round_dates(
 
         if assessment_start.casefold() == NONE:
             round_to_update.assessment_start = None
-        if assessment_start.casefold() == PAST:
+        elif assessment_start.casefold() == PAST:
             round_to_update.assessment_start = date_in_past
         elif assessment_start.casefold() == FUTURE:
             round_to_update.assessment_start = date_in_future

--- a/scripts/amend_round_dates.py
+++ b/scripts/amend_round_dates.py
@@ -1,51 +1,184 @@
 #!/usr/bin/env python3
-import argparse
 from datetime import datetime
 
+import click
+from config.fund_loader_config.cof.cof_r2 import rounds_config as cof_r2_configs
+from config.fund_loader_config.cof.cof_r3 import round_config as cof_r3w1_config
+from config.fund_loader_config.cof.cof_r3 import round_config_w2 as cof_r3w2_config
+from config.fund_loader_config.cof.cof_r3 import round_config_w3 as cof_r3w3_config
+from config.fund_loader_config.cof.cof_r4 import round_config_w1 as cof_r4_configs
+from config.fund_loader_config.cof.eoi import round_config_eoi as cof_eoi_configs
+from config.fund_loader_config.cyp.cyp_r1 import round_config as cyp_config
+from config.fund_loader_config.digital_planning.dpi_r2 import round_config as dpif_config
+from config.fund_loader_config.night_shelter.ns_r2 import round_config as nstf_config
 from db import db
 from db.models import Round
 
+ROUND_IDS = {
+    "COF_R2W2": "c603d114-5364-4474-a0c4-c41cbf4d3bbd",
+    "COF_R2W3": "5cf439bf-ef6f-431e-92c5-a1d90a4dd32f",
+    "COF_R3W1": "e85ad42f-73f5-4e1b-a1eb-6bc5d7f3d762",
+    "COF_R3W2": "6af19a5e-9cae-4f00-9194-cf10d2d7c8a7",
+    "COF_R3W3": "4efc3263-aefe-4071-b5f4-0910abec12d2",
+    "COF_R4W1": "33726b63-efce-4749-b149-20351346c76e",
+    "COF_EOI": "6a47c649-7bac-4583-baed-9c4e7a35c8b3",
+    "NSTF_R2": "fc7aa604-989e-4364-98a7-d1234271435a",
+    "CYP_R1": "888aae3d-7e2c-4523-b9c1-95952b3d1644",
+    "DPIF_R2": "0059aad4-5eb5-11ee-8c99-0242ac120002",
+}
 
-def update_round_dates(round_id, new_open_date, new_deadline, new_assessment_start, new_assessment_deadline):
+ALL_ROUNDS_CONFIG = {
+    ROUND_IDS["COF_R2W2"]: cof_r2_configs[0],
+    ROUND_IDS["COF_R2W3"]: cof_r2_configs[1],
+    ROUND_IDS["COF_R3W1"]: cof_r3w1_config[0],
+    ROUND_IDS["COF_R3W2"]: cof_r3w2_config[0],
+    ROUND_IDS["COF_R3W3"]: cof_r3w3_config[0],
+    ROUND_IDS["COF_R4W1"]: cof_r4_configs[0],
+    ROUND_IDS["COF_EOI"]: cof_eoi_configs[0],
+    ROUND_IDS["NSTF_R2"]: nstf_config[0],
+    ROUND_IDS["CYP_R1"]: cyp_config[0],
+    ROUND_IDS["DPIF_R2"]: dpif_config[0],
+}
+NONE = "NONE"
+UNCHANGED = "UNCHANGED"
+
+DEFAULTS = {
+    "round_short_name": None,
+}
+
+
+class DynamicPromptOption(click.Option):
+    def prompt_for_value(self, ctx):
+        q = ctx.obj.get("q")
+        if q:
+            return DEFAULTS.get(self.name, UNCHANGED)
+        return super().prompt_for_value(ctx)
+
+
+@click.group()
+@click.option("-q", help="Disable all prompts", flag_value=True, default=False)
+@click.pass_context
+def cli(ctx, q):
+    # Ensure that ctx.obj exists and is a dict
+    ctx.ensure_object(dict)
+    # Apply group-wide feature switches
+    ctx.obj["q"] = q
+
+
+@cli.command
+@click.option(
+    "-r",
+    "--round_short_name",
+    type=click.Choice(ROUND_IDS.keys()),
+    default="COF_R4W1",
+    prompt=True,
+    cls=DynamicPromptOption,
+    help="Short name for round, will be mapped to round ID. Not needed if round_id supplied.",
+)
+@click.option(
+    "-rid",
+    "--round_id",
+    prompt=False,
+    default=None,
+    help="UUID for round. Not needed if a valid round_short_name supplied",
+)
+@click.option(
+    "-o",
+    "--application_opens",
+    default=UNCHANGED,
+    prompt=True,
+    cls=DynamicPromptOption,
+    help="Application start date in format %Y-%m-%d %H:%M:%S. UNCHANGED will not update.",
+)
+@click.option(
+    "-d",
+    "--application_deadline",
+    default=UNCHANGED,
+    prompt=True,
+    cls=DynamicPromptOption,
+    help="Application deadline date in format %Y-%m-%d %H:%M:%S. UNCHANGED will not update.",
+)
+@click.option(
+    "-as",
+    "--assessment_start",
+    default=UNCHANGED,
+    prompt=True,
+    cls=DynamicPromptOption,
+    help="Assessment start date in format %Y-%m-%d %H:%M:%S. UNCHANGED will not update. NONE will set value to NONE",
+)
+@click.option(
+    "-ad",
+    "--assessment_deadline",
+    default=UNCHANGED,
+    prompt=True,
+    cls=DynamicPromptOption,
+    help="Assessment deadline date in format %Y-%m-%d %H:%M:%S. UNCHANGED will not update.",
+)
+def update_round_dates(
+    round_short_name=None,
+    round_id=None,
+    application_opens=None,
+    application_deadline=None,
+    assessment_start=None,
+    assessment_deadline=None,
+):
+    """Updates round dates for the supplied round ID."""
+    if not round_id:
+        round_id = ROUND_IDS[round_short_name]
+
     round_to_update = Round.query.get(round_id)
-    if new_open_date:
-        round_to_update.opens = datetime.strptime(new_open_date, "%Y-%m-%d %H:%M:%S")
+    commit = False
+    if application_opens and (not application_opens.casefold() == UNCHANGED.casefold()):
+        round_to_update.opens = datetime.strptime(application_opens, "%Y-%m-%d %H:%M:%S")
+        commit = True
+    if application_deadline and (not application_deadline.casefold() == UNCHANGED.casefold()):
+        round_to_update.deadline = datetime.strptime(application_deadline, "%Y-%m-%d %H:%M:%S")
+        commit = True
+    if assessment_start:
+        if assessment_start.casefold() == NONE.casefold():
+            round_to_update.assessment_start = None
+            commit = True
+        elif not assessment_start.casefold() == UNCHANGED.casefold():
+            round_to_update.assessment_start = datetime.strptime(assessment_start, "%Y-%m-%d %H:%M:%S")
+            commit = True
 
-    if new_deadline:
-        round_to_update.deadline = datetime.strptime(new_deadline, "%Y-%m-%d %H:%M:%S")
+    if assessment_deadline and (not assessment_deadline.casefold() == UNCHANGED.casefold()):
+        round_to_update.assessment_deadline = datetime.strptime(assessment_deadline, "%Y-%m-%d %H:%M:%S")
+        commit = True
 
-    if new_assessment_start:
-        round_to_update.assessment_start = datetime.strptime(new_assessment_start, "%Y-%m-%d %H:%M:%S")
-
-    if new_assessment_deadline:
-        round_to_update.assessment_deadline = datetime.strptime(new_assessment_deadline, "%Y-%m-%d %H:%M:%S")
-
-    if new_open_date or new_deadline or new_assessment_start or new_assessment_deadline:
+    if commit:
         db.session.commit()
-        print(f"Sucessfully updated the round dates for {round_id}.")
+        print(f"Sucessfully updated the round dates for {round_short_name if round_short_name else ''} [{round_id}].")
+    else:
+        print("No changes supplied")
+    return
 
 
-def init_argparse() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--round_id", help="Provide round id of a fund", required=True)
-    parser.add_argument("--opens_date", help="Provide Round open date", required=False)
-    parser.add_argument("--deadline_date", help="Provide Round deadline date", required=False)
-    parser.add_argument("--assessment_start_date", help="Provide Round assessment start date", required=False)
-    parser.add_argument(
-        "--assessment_deadline_date",
-        help="Provide Assessment deadline for the round",
-        required=False,
-    )
-    return parser
+@cli.command
+@click.option(
+    "-r",
+    "--round_short_name",
+    type=click.Choice(ROUND_IDS.keys()),
+    default="COF_R4W1",
+    prompt=True,
+    cls=DynamicPromptOption,
+)
+@click.option("-rid", "--round_id", prompt=False, default=None)
+def reset_round_dates(round_id, round_short_name):
+    """Resets the dates for the supplied round to the dates in the fund loader config"""
+    if not round_id:
+        round_id = ROUND_IDS[round_short_name]
 
-
-def main() -> None:
-    parser = init_argparse()
-    args = parser.parse_args()
-    round_id = args.round_id
-
-    update_round_dates(
-        round_id, args.opens_date, args.deadline_date, args.assessment_start_date, args.assessment_deadline_date
+    round_to_update = Round.query.get(round_id)
+    reset_config = ALL_ROUNDS_CONFIG[round_id]
+    round_to_update.opens = reset_config["opens"]
+    round_to_update.deadline = reset_config["deadline"]
+    round_to_update.assessment_start = reset_config["assessment_start"]
+    round_to_update.assessment_deadline = reset_config["assessment_deadline"]
+    db.session.commit()
+    print(
+        f"Sucessfully reset the round dates for {round_short_name if round_short_name else ''} [{round_id}] to the"
+        " dates in the fund loader config"
     )
 
 
@@ -53,4 +186,4 @@ if __name__ == "__main__":
     from app import app
 
     with app.app_context():
-        main()
+        cli()


### PR DESCRIPTION
Update the amend_round_dates script to:
- Work with setting the assessment_start_date to blank
- Allow passing in of a short name for a round, not just the round id. eg. COF_R4W1
- Offer a function to reset the dates to those in the fund loader config

TODO: Update the confluence page to include example commands to eg. open a round, force open assessment etc. https://dluhcdigital.atlassian.net/wiki/spaces/FS/pages/83526002/Common+Dev+Actions#Update-local-fund-round-dates