### PR TITLE
FS-4413: Auction-costs section removed from fund loader config for HSRA

### DIFF
--- a/config/fund_loader_config/hsra/hsra.py
+++ b/config/fund_loader_config/hsra/hsra.py
@@ -84,14 +84,9 @@ hsra_sections = [
         "tree_path": f"{APPLICATION_BASE_PATH_HSRA}.4.2",
     },
     {
-        "section_name": {"en": "Auction costs", "cy": ""},
-        "form_name_json": {"en": "auction-costs-hsra", "cy": ""},
-        "tree_path": f"{APPLICATION_BASE_PATH_HSRA}.4.3",
-    },
-    {
         "section_name": {"en": "Other costs", "cy": ""},
         "form_name_json": {"en": "other-costs-hsra", "cy": ""},
-        "tree_path": f"{APPLICATION_BASE_PATH_HSRA}.4.4",
+        "tree_path": f"{APPLICATION_BASE_PATH_HSRA}.4.3",
     },
     {
         "section_name": {"en": "5. Declaration", "cy": ""},


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/FFE-266


### Change description
- Auction-costs section removed from fund loader config for HSRA


- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
- Run the scripts.load_all_fund_rounds and verify if auction costs is removed from the application


### Screenshots of UI changes (if applicable)

<img width="834" alt="Screenshot 2024-05-24 at 07 04 25" src="https://github.com/communitiesuk/funding-service-design-fund-store/assets/66220499/2a9b4f7a-d4e8-4549-946c-0fb712751fd9">