### PR TITLE
fs-4430 updating dates for COF EOI and R4W2 following election announcement

### DIFF
--- a/config/fund_loader_config/cof/cof_r4.py
+++ b/config/fund_loader_config/cof/cof_r4.py
@@ -29,11 +29,15 @@ COF_R4W1_DEADLINE_DATE = datetime(2024, 4, 10, 14, 00, 0, tzinfo=timezone.utc)  
 COF_R4W1_ASSESSMENT_DEADLINE_DATE = datetime(2024, 6, 23, 12, 0, 0, tzinfo=timezone.utc)  # 2024-06-23 12:00:00
 
 
-# TODO Dates are still being debated and are likely to change
 COF_R4W2_OPENS_DATE = datetime(2024, 5, 22, 14, 00, 0, tzinfo=timezone.utc)  # 2024-05-22 14:00:00
 COF_R4W2_SEND_REMINDER_DATE = datetime(2024, 5, 22, 11, 59, 0, tzinfo=timezone.utc)  # 2024-05-22 11:59:00
 COF_R4W2_DEADLINE_DATE = datetime(2024, 6, 26, 14, 00, 0, tzinfo=timezone.utc)  # 2024-06-26 14:00:00
+COF_R4W2_ASSESSMENT_START_DATE = datetime(2024, 5, 22, 14, 00, 0, tzinfo=timezone.utc)  # 2024-05-22 14:00:00
 COF_R4W2_ASSESSMENT_DEADLINE_DATE = datetime(2024, 7, 31, 12, 0, 0, tzinfo=timezone.utc)  # 2024-07-31 12:00:00
+
+# Date far in the future as a temporary measure to stop this going live by accident
+COF_R4W2_HOLD_DATE = datetime(2124, 1, 1, 11, 59, 0)  # 2124-01-01 11:59:00
+
 
 cof_r4w1_sections = [
     {
@@ -569,12 +573,12 @@ round_config_w2 = [
         "fund_id": COF_FUND_ID,
         "title_json": {"en": "Round 4 Window 2", "cy": "Round 4 Window 2"},
         "short_name": "R4W2",
-        "opens": COF_R4W2_OPENS_DATE,
-        "assessment_start": datetime(2024, 5, 22, 14, 00, 0, tzinfo=timezone.utc),
-        "deadline": COF_R4W2_DEADLINE_DATE,
+        "opens": COF_R4W2_HOLD_DATE,
+        "assessment_start": COF_R4W2_HOLD_DATE,
+        "deadline": COF_R4W2_HOLD_DATE,
         "application_reminder_sent": False,
-        "reminder_date": COF_R4W2_SEND_REMINDER_DATE,
-        "assessment_deadline": COF_R4W2_ASSESSMENT_DEADLINE_DATE,
+        "reminder_date": COF_R4W2_HOLD_DATE,
+        "assessment_deadline": COF_R4W2_HOLD_DATE,
         "prospectus": "https://www.gov.uk/government/publications/community-ownership-fund-prospectus",
         "privacy_notice": (
             "https://www.gov.uk/government/publications/community-ownership-fund-"

--- a/config/fund_loader_config/cof/eoi.py
+++ b/config/fund_loader_config/cof/eoi.py
@@ -20,7 +20,7 @@ ASSESSMENT_BASE_PATH_COF_EOI = ".".join([str(COF_EOI_BASE_PATH), str(2)])
 
 COF_EOI_OPENS_DATE = datetime(2024, 3, 6, 14, 00, 0, tzinfo=timezone.utc)  # 2023-12-06 14:00:00
 COF_EOI_ASSESSMENT_OPENS_DATE = COF_EOI_OPENS_DATE
-COF_EOI_DEADLINE_DATE = datetime(2124, 3, 6, 11, 59, 0, tzinfo=timezone.utc)  # 2124-03-06 11:59:00
+COF_EOI_DEADLINE_DATE = datetime(2024, 5, 25, 0, 1, 0, tzinfo=timezone.utc)  # 2024-05-25 00:01:00 (1min past midnight)
 COF_EOI_ASSESSMENT_DEADLINE_DATE = datetime(2124, 3, 6, 12, 0, 0, tzinfo=timezone.utc)  # 2124-03-06 12:00:00
 
 fund_config = {


### PR DESCRIPTION
Updated the dates as follows:
**EOI**
- Application deadline: 00:01am on 25th May 2024

**COF R4W2**
- Application open, application deadline, assessment start, assessment deadline: 11:59am on 1st January *2124*
The reason for setting it far in the future is that if anyone imports this to production by mistake, it won't show up on application - if someone guesses the URL they will get the 404 as normal for rounds that don't exist or have yet to open.