### PR TITLE
Update COF support email to communities from levellingup

### DIFF
--- a/config/fund_loader_config/cof/cof_r2.py
+++ b/config/fund_loader_config/cof/cof_r2.py
@@ -80,7 +80,7 @@ rounds_config = [
             """
             ),
         },
-        "contact_email": "COF@levellingup.gov.uk",
+        "contact_email": "COF@communities.gov.uk",
         "contact_phone": None,
         "contact_textphone": None,
         "support_times": "9am to 5pm",
@@ -182,7 +182,7 @@ rounds_config = [
             """
             ),
         },
-        "contact_email": "COF@levellingup.gov.uk",
+        "contact_email": "COF@communities.gov.uk",
         "contact_phone": None,
         "contact_textphone": None,
         "support_times": "9am to 5pm",

--- a/config/fund_loader_config/cof/cof_r3.py
+++ b/config/fund_loader_config/cof/cof_r3.py
@@ -770,7 +770,7 @@ round_config = [
             """
             ),
         },
-        "contact_email": "COF@levellingup.gov.uk",
+        "contact_email": "COF@communities.gov.uk",
         "contact_phone": None,
         "contact_textphone": None,
         "support_times": "9am to 5pm",
@@ -872,7 +872,7 @@ round_config_w2 = [
             """
             ),
         },
-        "contact_email": "COF@levellingup.gov.uk",
+        "contact_email": "COF@communities.gov.uk",
         "contact_phone": None,
         "contact_textphone": None,
         "support_times": "9am to 5pm",
@@ -974,7 +974,7 @@ round_config_w3 = [
             """
             ),
         },
-        "contact_email": "COF@levellingup.gov.uk",
+        "contact_email": "COF@communities.gov.uk",
         "contact_phone": None,
         "contact_textphone": None,
         "support_times": "9am to 5pm",

--- a/config/fund_loader_config/cof/cof_r4.py
+++ b/config/fund_loader_config/cof/cof_r4.py
@@ -520,7 +520,7 @@ round_config_w1 = [
             """
             ),
         },
-        "contact_email": "COF@levellingup.gov.uk",
+        "contact_email": "COF@communities.gov.uk",
         "contact_phone": None,
         "contact_textphone": None,
         "support_times": "9am to 5pm",
@@ -623,7 +623,7 @@ round_config_w2 = [
             """
             ),
         },
-        "contact_email": "COF@levellingup.gov.uk",
+        "contact_email": "COF@communities.gov.uk",
         "contact_phone": None,
         "contact_textphone": None,
         "support_times": "9am to 5pm",

--- a/config/fund_loader_config/cof/eoi.py
+++ b/config/fund_loader_config/cof/eoi.py
@@ -166,7 +166,7 @@ round_config_eoi = [
             """
             ),
         },
-        "contact_email": "COF@levellingup.gov.uk",
+        "contact_email": "COF@communities.gov.uk",
         "contact_phone": None,
         "contact_textphone": None,
         "support_times": "9am to 5pm",


### PR DESCRIPTION

### Change description
The old COF support email was using the levellingup domain ( [cof@levellingup.gov.uk](mailto:cof@levellingup.gov.uk) ). This has been updated to the communities domain ( [cof@communities.gov.uk](mailto:cof@communities.gov.uk) )

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
