### PR TITLE
Only read python files for fund config

### DIFF
--- a/config/fund_loader_config/FAB/__init__.py
+++ b/config/fund_loader_config/FAB/__init__.py
@@ -31,8 +31,9 @@ FAB_FUND_ROUND_CONFIGS = {}
 this_dir = Path("config") / "fund_loader_config" / "FAB"
 
 for file in os.listdir(this_dir):
-    if "__" in file.title():
+    if file.startswith("__") or not file.endswith(".py"):
         continue
+
     with open(this_dir / file, "r") as json_file:
 
         content = json_file.read()


### PR DESCRIPTION
### Change description
Sometimes you can end up with system files in this directory (eg .DS_Store) and we don't want to read those. We only want to read fund config python files.

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
